### PR TITLE
Fixed date format from YYYY (year of "Week of Year") to yyyy (year)

### DIFF
--- a/TransformerKit/TTTDateTransformers.m
+++ b/TransformerKit/TTTDateTransformers.m
@@ -34,7 +34,7 @@ static NSString * TTTISO8601TimestampFromDate(NSDate *date) {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         _iso8601DateFormatter = [[NSDateFormatter alloc] init];
-        [_iso8601DateFormatter setDateFormat:@"YYYY-MM-dd'T'HH:mm:ssZ"];
+        [_iso8601DateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
         [_iso8601DateFormatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
     });
 


### PR DESCRIPTION
I think what's meant here is yyyy instead of YYYY.

See http://userguide.icu-project.org/formatparse/datetime for more info.

This caused me some unexpected results.
