### PR TITLE
Change podspec outermost source_files to only include TransformerKit/TransformerKit.h

### DIFF
--- a/TransformerKit.podspec
+++ b/TransformerKit.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/mattt/TransformerKit'
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
   s.source   = { :git => 'https://github.com/mattt/TransformerKit.git', :tag => '0.4.0' }
-  s.source_files = 'TransformerKit'
+  s.source_files = 'TransformerKit/TransformerKit.h'
 
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'


### PR DESCRIPTION
Previously `s.source_files = 'TransformerKit'` included all files under TransformerKit, and then each subspec also added its own files. The Pods-TransformerKit Xcode target double-included each .m file from the subspecs when using plain `pod 'TransformerKit'`, causing linker errors. Change to just include TransformerKit.h, and then each subspec is responsible for its own files.

The spec also needs to be fixed in the CocoaPods/Specs repo, but seemed I should report here first.
