### PR TITLE
Remove `source_files` from top-level podspec

### DIFF
--- a/TransformerKit.podspec
+++ b/TransformerKit.podspec
@@ -6,7 +6,6 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/mattt/TransformerKit'
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
   s.source   = { :git => 'https://github.com/mattt/TransformerKit.git', :tag => '0.5.0' }
-  s.source_files = 'TransformerKit'
 
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'


### PR DESCRIPTION
Because of that line all source files were added to the project when you specify `pod 'TransformerKit'` and `pod spec lint` was failing because `Security` framework is needed for `TransformerKit/Data`, but wasn't added as dependency. Looks like now developers need to specify what parts (subspecs) of the library do they need. For example in my case `pod 'TransformerKit/String'` works well.

This change has been already merged into CocoaPods/Specs#11113
