### PR TITLE
Prevent crash on 10.7

### DIFF
--- a/TransformerKit/NSValueTransformer+TransformerKit.m
+++ b/TransformerKit/NSValueTransformer+TransformerKit.m
@@ -79,6 +79,8 @@
         Method allowsReverseTransformationMethod;
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && (!defined(__IPHONE_5_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_5_0)
         allowsReverseTransformationMethod = class_getClassMethod(class, allowsReverseTransformationSelector);
+#elif defined(MAC_OS_X_VERSION_MIN_REQUIRED) && (!defined(MAC_OS_X_VERSION_10_8) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_8)
+        allowsReverseTransformationMethod = class_getClassMethod(class, allowsReverseTransformationSelector);
 #else
         allowsReverseTransformationMethod = class_getInstanceMethod(class, allowsReverseTransformationSelector);
 #endif


### PR DESCRIPTION
Calling `class_getInstanceMethod(class, allowsReverseTransformationSelector)` crashes OS X 10.7. I’m a little confused why it works on 10.8+ (since it’s a class method, correct)? Anyway, this patch doesn’t crash 10.7 and works with 10.8+ as well
